### PR TITLE
feat: mentoring registration API develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/developers/live/developers/mentoring/config/RedisConfig.java
+++ b/src/main/java/com/developers/live/developers/mentoring/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package com.developers.live.developers.mentoring.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  public String host;
+
+  @Value("${spring.data.redis.port}")
+  public int port;
+
+  @Bean
+  public RedisConnectionFactory cacheRedisConnectionFactory() {
+    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+    configuration.setDatabase(0);
+
+    final SocketOptions socketoptions = SocketOptions.builder().connectTimeout(Duration.ofSeconds(10)).build();
+    final ClientOptions clientoptions = ClientOptions.builder().socketOptions(socketoptions).build();
+
+    LettuceClientConfiguration lettuceClientConfiguration = LettuceClientConfiguration.builder().clientOptions(clientoptions)
+            .commandTimeout(Duration.ofSeconds(10)).shutdownTimeout(Duration.ZERO)
+            .build();
+    return new LettuceConnectionFactory(configuration, lettuceClientConfiguration);
+  }
+
+  @Bean(name = "redisTemplate")
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(cacheRedisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/developers/live/developers/mentoring/controller/RegisterController.java
+++ b/src/main/java/com/developers/live/developers/mentoring/controller/RegisterController.java
@@ -1,0 +1,30 @@
+package com.developers.live.developers.mentoring.controller;
+
+import com.developers.live.developers.mentoring.dto.RegisterRequestDto;
+import com.developers.live.developers.mentoring.dto.RegisterResponseDto;
+import com.developers.live.developers.mentoring.service.RegisterService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/register")
+@RestController
+public class RegisterController {
+
+  private final RegisterService registerService;
+
+  @PostMapping("")
+  public ResponseEntity<RegisterResponseDto> register(@RequestBody @Valid RegisterRequestDto request) {
+    RegisterResponseDto response = registerService.register(request);
+    log.info("멘티의 멘토링 신청 요청");
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/RegisterRequestDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/RegisterRequestDto.java
@@ -1,0 +1,22 @@
+package com.developers.live.developers.mentoring.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class RegisterRequestDto {
+
+  @NotNull
+  private Long scheduleId;
+
+  @NotNull
+  private Long menteeId;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/RegisterResponseDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/RegisterResponseDto.java
@@ -1,0 +1,16 @@
+package com.developers.live.developers.mentoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class RegisterResponseDto {
+  private String code;
+  private String msg;
+  private String data;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
+++ b/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 @SQLDelete(sql = "update mentoring_room_schedule set deleted_at = CURRENT_TIMESTAMP where schedule_id = ?")
 @Table(name = "mentoring_room_schedule")
 @Entity
+@DynamicUpdate
 public class Schedule extends BaseTime {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
+++ b/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -38,6 +39,10 @@ public class Schedule extends BaseTime {
   private LocalDateTime start;
   @Column(name = "end", nullable = false)
   private LocalDateTime end;
+
+  public void changeMentee(Long menteeId) {
+    this.menteeId = menteeId;
+  }
 
   @Builder
   public Schedule(Long mentoringRoomId, Long mentorId, Long menteeId, LocalDateTime start, LocalDateTime end) {

--- a/src/main/java/com/developers/live/developers/mentoring/service/RegisterService.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/RegisterService.java
@@ -1,0 +1,9 @@
+package com.developers.live.developers.mentoring.service;
+
+import com.developers.live.developers.mentoring.dto.RegisterRequestDto;
+import com.developers.live.developers.mentoring.dto.RegisterResponseDto;
+
+public interface RegisterService {
+
+  RegisterResponseDto register(RegisterRequestDto request);
+}

--- a/src/main/java/com/developers/live/developers/mentoring/service/RegisterServiceImpl.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/RegisterServiceImpl.java
@@ -1,0 +1,59 @@
+package com.developers.live.developers.mentoring.service;
+
+import com.developers.live.developers.mentoring.dto.RegisterRequestDto;
+import com.developers.live.developers.mentoring.dto.RegisterResponseDto;
+import com.developers.live.developers.mentoring.entity.Schedule;
+import com.developers.live.developers.mentoring.repository.ScheduleRespository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class RegisterServiceImpl implements RegisterService {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  private final ScheduleRespository scheduleRespository;
+
+  @Transactional
+  @Override
+  public RegisterResponseDto register(RegisterRequestDto request) {
+    Optional<Schedule> schedule = scheduleRespository.findById(request.getScheduleId());
+
+    if (schedule.isPresent()) {
+      if (schedule.get().getMenteeId() == null) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+
+        valueOperations.set(String.valueOf(request.getScheduleId()), request.getMenteeId());
+
+        Long registeredMentee = Long.parseLong(String.valueOf(valueOperations.get(String.valueOf(request.getScheduleId()))));
+
+        if (request.getMenteeId().equals(registeredMentee)) {
+          schedule.get().changeMentee(request.getMenteeId());
+
+          return RegisterResponseDto.builder()
+                  .code(String.valueOf(HttpStatus.OK))
+                  .msg("정상적으로 신청이 완료되었습니다.")
+                  .data(String.valueOf(request.getMenteeId()))
+                  .build();
+        }
+      }
+      return RegisterResponseDto.builder()
+              .code(String.valueOf(HttpStatus.NOT_FOUND))
+              .msg("이미 예약된 멘토링 일정입니다.")
+              .data(null)
+              .build();
+    }
+    return RegisterResponseDto.builder()
+            .code(String.valueOf(HttpStatus.NOT_FOUND))
+            .msg("방에 대한 정보를 찾지 못했습니다.")
+            .data(null)
+            .build();
+  }
+}

--- a/src/main/java/com/developers/live/developers/mentoring/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/ScheduleServiceImpl.java
@@ -43,7 +43,7 @@ public class ScheduleServiceImpl implements ScheduleService {
       response = ScheduleAddResponseDto.builder()
               .code(String.valueOf(HttpStatus.NOT_FOUND))
               .msg("방에 대한 정보를 찾지 못했습니다.")
-              .data("null")
+              .data(null)
               .build();
     }
     return response;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: local
     group:
       local: local
       dev: dev

--- a/src/test/java/com/developers/live/developers/service/RegisterServiceTest.java
+++ b/src/test/java/com/developers/live/developers/service/RegisterServiceTest.java
@@ -1,0 +1,33 @@
+package com.developers.live.developers.service;
+
+import com.developers.live.developers.mentoring.dto.RegisterRequestDto;
+import com.developers.live.developers.mentoring.dto.RegisterResponseDto;
+import com.developers.live.developers.mentoring.entity.Schedule;
+import com.developers.live.developers.mentoring.service.RegisterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class RegisterServiceTest {
+
+  @Autowired RegisterService registerService;
+  @Test
+  public void 멘토링_신청() {
+    // given
+    RegisterRequestDto request = RegisterRequestDto.builder()
+            .scheduleId(3L)
+            .menteeId(2L)
+            .build();
+
+    // when
+    RegisterResponseDto response = registerService.register(request);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+    assertThat(response.getData()).isEqualTo(String.valueOf(request.getMenteeId()));
+  }
+}


### PR DESCRIPTION
## 🤔 Motivation
- 사용자의 멘토링 신청 API 개발

<br>

## 💡 Key Changes
- 멘토링 신청할 때 동시성 이슈(더블 부킹)로 인해 redis를 사용해 싱글 스레드 기반으로 수강 신청이 이루어지도록 했습니다.
- redis에는 key로 scheduleId, value로 menteeId 가 들어갑니다.
- 특정 schedule에 대해 신청이 들어오면 먼저 RDB 의 값을 참조해 mentee Id에 값이 있다고 판단되면 이미 예약된 신청이라 메시지를 반환합니다.
이때 mentee Id가 null 값이면 redis에 먼저 저장한 후, schedule Id로 가져온 mentee Id가 자신의 고유회원번호와 같은지 비교 후, 같다면 RDB에도 저장해주고 성공 메시지를 반환하고 그렇지 않다면 실패 메시지를 반환합니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @Jooney-95 
- @paduck-96 
- @ITfervor 
- @EagerProgrammer 

closd #11 