### PR TITLE
feat: develop update mentoring room info API

### DIFF
--- a/src/main/java/com/developers/live/developers/mentoring/controller/RoomController.java
+++ b/src/main/java/com/developers/live/developers/mentoring/controller/RoomController.java
@@ -1,12 +1,11 @@
 package com.developers.live.developers.mentoring.controller;
 
-import com.developers.live.developers.mentoring.dto.RoomAddRequestDto;
-import com.developers.live.developers.mentoring.dto.RoomAddResponseDto;
-import com.developers.live.developers.mentoring.dto.RoomListResponseDto;
+import com.developers.live.developers.mentoring.dto.*;
 import com.developers.live.developers.mentoring.service.RoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +21,14 @@ public class RoomController {
      * RoomController에 포함된 비즈니스 로직은 RoomService 구현체에서 수행하도록 수정해야 한다.
      */
 
-    @GetMapping("")
+    @GetMapping
     public ResponseEntity<RoomListResponseDto> roomList() {
         RoomListResponseDto response = roomService.getList();
         log.info("방 전체 목록 조회: " + response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PostMapping("")
+    @PostMapping
     public ResponseEntity<RoomAddResponseDto> roomInit(@RequestBody @Valid RoomAddRequestDto request) {
         RoomAddResponseDto response = roomService.addRoom(request);
         log.info("방 생성: " + response);
@@ -47,6 +46,13 @@ public class RoomController {
     public ResponseEntity<RoomListResponseDto> roomListWithRecent() {
         RoomListResponseDto response = roomService.getListWithRecent();
         log.info("최신순으로 정렬 후 목록 조회: " + response);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping("/update")
+    public ResponseEntity<RoomUpdateResponseDto> roomUpdate(@RequestBody @Valid RoomUpdateRequestDto request) {
+        RoomUpdateResponseDto response = roomService.updateRoom(request);
+        log.info("방 정보 업데이트: " + response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/developers/live/developers/mentoring/dto/RoomUpdateRequestDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/RoomUpdateRequestDto.java
@@ -1,0 +1,24 @@
+package com.developers.live.developers.mentoring.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class RoomUpdateRequestDto {
+
+  @NotNull
+  private Long mentoringRoomId;
+
+  @NotBlank
+  private String title;
+
+  @NotBlank
+  private String description;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/dto/RoomUpdateResponseDto.java
+++ b/src/main/java/com/developers/live/developers/mentoring/dto/RoomUpdateResponseDto.java
@@ -1,0 +1,16 @@
+package com.developers.live.developers.mentoring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class RoomUpdateResponseDto {
+  private String code;
+  private String msg;
+  private String data;
+}

--- a/src/main/java/com/developers/live/developers/mentoring/entity/Room.java
+++ b/src/main/java/com/developers/live/developers/mentoring/entity/Room.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -19,12 +20,13 @@ import java.util.List;
 @SQLDelete(sql = "update mentoring_room set deleted_at = CURRENT_TIMESTAMP where mentoring_room_id = ?")
 @Table(name = "mentoring_room")
 @Entity
+@DynamicUpdate
 public class Room extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mentoringRoomId", nullable = false)
+    @Column(name = "mentoring_room_id", nullable = false)
     private Long mentoringRoomId;
-    @Column(name = "mentorId", nullable = false)
+    @Column(name = "mentor_id", nullable = false)
     private Long mentorId;
     @Column(name = "title", nullable = false, length = 50)
     private String title;
@@ -35,6 +37,11 @@ public class Room extends BaseTime {
 
     @OneToMany(mappedBy = "mentoringRoomId")
     private List<Schedule> schedules = new ArrayList<>();
+
+    public void updateRoomInfo(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
 
     @Builder
     public Room(Long mentorId, String title, String description, Long point) {

--- a/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
+++ b/src/main/java/com/developers/live/developers/mentoring/entity/Schedule.java
@@ -28,13 +28,13 @@ import java.time.LocalDateTime;
 public class Schedule extends BaseTime {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "scheduleId", nullable = false)
+  @Column(name = "schedule_id", nullable = false)
   private Long scheduleId;
-  @Column(name = "mentoringRoomId", nullable = false)
+  @Column(name = "mentoring_room_id", nullable = false)
   private Long mentoringRoomId;
-  @Column(name = "mentorId", nullable = false)
+  @Column(name = "mentor_id", nullable = false)
   private Long mentorId;
-  @Column(name = "menteeId")
+  @Column(name = "mentee_id")
   private Long menteeId;
   @Column(name = "start", nullable = false)
   private LocalDateTime start;

--- a/src/main/java/com/developers/live/developers/mentoring/service/RoomService.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/RoomService.java
@@ -1,12 +1,7 @@
 package com.developers.live.developers.mentoring.service;
 
-import com.developers.live.developers.mentoring.dto.RoomAddRequestDto;
-import com.developers.live.developers.mentoring.dto.RoomAddResponseDto;
-import com.developers.live.developers.mentoring.dto.RoomGetDto;
-import com.developers.live.developers.mentoring.dto.RoomListResponseDto;
+import com.developers.live.developers.mentoring.dto.*;
 import com.developers.live.developers.mentoring.entity.Room;
-
-import java.util.List;
 
 public interface RoomService {
 
@@ -14,6 +9,7 @@ public interface RoomService {
   RoomAddResponseDto addRoom(RoomAddRequestDto req);
   RoomListResponseDto getListWithSearch(String param);
   RoomListResponseDto getListWithRecent();
+  RoomUpdateResponseDto updateRoom(RoomUpdateRequestDto req);
 
   default RoomGetDto entityToDto(Room entity) {
     return RoomGetDto.builder()

--- a/src/main/java/com/developers/live/developers/mentoring/service/RoomServiceImpl.java
+++ b/src/main/java/com/developers/live/developers/mentoring/service/RoomServiceImpl.java
@@ -1,17 +1,15 @@
 package com.developers.live.developers.mentoring.service;
 
-import com.developers.live.developers.mentoring.dto.RoomAddRequestDto;
-import com.developers.live.developers.mentoring.dto.RoomAddResponseDto;
-import com.developers.live.developers.mentoring.dto.RoomGetDto;
-import com.developers.live.developers.mentoring.dto.RoomListResponseDto;
+import com.developers.live.developers.mentoring.dto.*;
 import com.developers.live.developers.mentoring.entity.Room;
 import com.developers.live.developers.mentoring.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -65,5 +63,32 @@ public class RoomServiceImpl implements RoomService {
             .msg("정상적으로 최신순으로 정렬된 채팅방 목록이 조회되었습니다.")
             .data(dtoList)
             .build();
+  }
+
+  @Override
+  @Transactional
+  public RoomUpdateResponseDto updateRoom(RoomUpdateRequestDto req) {
+    Optional<Room> optionalRoom = roomRepository.findById(req.getMentoringRoomId());
+
+    RoomUpdateResponseDto response;
+    if (optionalRoom.isPresent()) {
+      Room room = optionalRoom.get();
+
+      room.updateRoomInfo(req.getTitle(), req.getDescription());
+
+      response = RoomUpdateResponseDto.builder()
+              .code(HttpStatus.OK.name())
+              .msg("방 정보 수정이 완료되었습니다.")
+              .data(String.valueOf(req.getMentoringRoomId()))
+              .build();
+    }
+    else {
+      response = RoomUpdateResponseDto.builder()
+              .code(HttpStatus.NOT_FOUND.name())
+              .msg("수정하려는 방의 정보를 찾을 수 없습니다.")
+              .data(null)
+              .build();
+    }
+    return response;
   }
 }

--- a/src/test/java/com/developers/live/developers/service/RoomServiceTest.java
+++ b/src/test/java/com/developers/live/developers/service/RoomServiceTest.java
@@ -1,8 +1,6 @@
 package com.developers.live.developers.service;
 
-import com.developers.live.developers.mentoring.dto.RoomAddRequestDto;
-import com.developers.live.developers.mentoring.dto.RoomAddResponseDto;
-import com.developers.live.developers.mentoring.dto.RoomListResponseDto;
+import com.developers.live.developers.mentoring.dto.*;
 import com.developers.live.developers.mentoring.service.RoomService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,5 +67,21 @@ public class RoomServiceTest {
 
     // then
     System.out.println("최신순으로 정렬한 멘토링룸 목록: " + roomList.getData());
+  }
+
+  @Test
+  void 방_정보_수정() {
+    // given
+    RoomUpdateRequestDto request = RoomUpdateRequestDto.builder()
+            .mentoringRoomId(1L)
+            .title("수정된 방제")
+            .description("수정된 방 소개")
+            .build();
+
+    // when
+    RoomUpdateResponseDto response = roomService.updateRoom(request);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.name());
   }
 }


### PR DESCRIPTION
## 🤔 Motivation
- @Column 어노테이션의 name 속성을 snake 표기법으로 변경
- 멘토링룸 정보 수정 API 개발

<br>

## 💡 Key Changes
- 멘토링룸 정보 수정 요청 때 받는 데이터 `RoomUpdateRequestDto`의 유효성 검사에서 방 정보를 수정하지 않고자할 때의 Null 검사 관련 고민이 있었습니다. 하지만 결국 넘어오는 데이터는 최종으로 수정될 데이터를 가져오는 것이기 때문에 `@NotBlank` 어노테이션으로 Null, 빈값, 스페이스만 있는 경우 모두 검사에서 걸리도록 구현했습니다.
같은 맥락으로 처음, 방제 수정과 방 소개글 수정을 따로 나누려고 했던 것도 `updateRoomInfo` 라는 이름으로 한꺼번에 변경하도록 했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 

close #16 
close #17  