### PR TITLE
fix: mentoring room list read API

### DIFF
--- a/src/main/java/com/developers/live/mentoring/config/CacheConfig.java
+++ b/src/main/java/com/developers/live/mentoring/config/CacheConfig.java
@@ -7,7 +7,7 @@ import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableCaching
@@ -16,9 +16,8 @@ public class CacheConfig {
   @Bean
   public CacheManager cacheManager() {
     SimpleCacheManager cacheManager = new SimpleCacheManager();
-    cacheManager.setCaches(Arrays.asList(
-            new ConcurrentMapCache("firstMentoringRoomList"),
-            new ConcurrentMapCache("spareMentoringRoomList")
+    cacheManager.setCaches(List.of(
+            new ConcurrentMapCache("mentoringRoomList")
     ));
     return cacheManager;
   }

--- a/src/main/java/com/developers/live/mentoring/controller/RegisterController.java
+++ b/src/main/java/com/developers/live/mentoring/controller/RegisterController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Log4j2
 @RequiredArgsConstructor

--- a/src/main/java/com/developers/live/mentoring/controller/RoomController.java
+++ b/src/main/java/com/developers/live/mentoring/controller/RoomController.java
@@ -38,8 +38,8 @@ public class RoomController {
 
     @GetMapping("/next")
     public ResponseEntity<RoomListResponseDto> getSpareList(@RequestParam("lastDateTime") LocalDateTime lastDateTime) {
-        RoomListResponseDto response = roomService.getSpareCacheList(lastDateTime);
-        log.info("예비 저장소에 저장된 데이터");
+        RoomListResponseDto response = roomService.getNextList(lastDateTime);
+        log.info("다음 데이터: " + response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/developers/live/mentoring/dto/RegisterRequestDto.java
+++ b/src/main/java/com/developers/live/mentoring/dto/RegisterRequestDto.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/developers/live/mentoring/service/CachingRoomService.java
+++ b/src/main/java/com/developers/live/mentoring/service/CachingRoomService.java
@@ -10,17 +10,13 @@ import org.springframework.web.client.UnknownHttpStatusCodeException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
 public interface CachingRoomService {
 
   void removeFirstMentoringRoomList();
-  void removeSpareMentoringRoomList();
   List<RoomGetDto> getAndUpdateFirstCacheStorage();
-  List<RoomGetDto> initSpareCacheStorage();
-  List<RoomGetDto> getAndUpdateSpareCacheStorage(LocalDateTime lastDateTime);
 
   default String getMentorName(Long mentorId) {
     RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/com/developers/live/mentoring/service/CachingRoomServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/CachingRoomServiceImpl.java
@@ -5,13 +5,11 @@ import com.developers.live.mentoring.entity.Room;
 import com.developers.live.mentoring.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -23,38 +21,14 @@ public class CachingRoomServiceImpl implements CachingRoomService {
 
   // 첫번째 저장소 비우기
   @Override
-  @CacheEvict(value = "firstMentoringRoomList")
+  @CacheEvict(cacheNames = "mentoringRoomList")
   public void removeFirstMentoringRoomList() { }
-
-  // 예비 저장소 비우기
-  @Override
-  @CacheEvict(value = "spareMentoringRoomList")
-  public void removeSpareMentoringRoomList() { }
 
   // 첫번째 저장소 내용을 DB 정보로 update 한다.
   @Override
-  @Cacheable(value = "firstMentoringRoomList")
+  @Cacheable(cacheNames = "mentoringRoomList")
   public List<RoomGetDto> getAndUpdateFirstCacheStorage() {
     List<Room> firstMentoringRoomList = roomRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(0, 100));
     return firstMentoringRoomList.stream().map(room -> entityToDto(room)).toList();
-  }
-
-  // 첫 목록 조회 요청, 새로 고침 등의 상황에서 첫번째 데이터 다음의 데이터로 예비 저장소를 채워놓는다.
-  @Override
-  @CachePut(value = "spareMentoringRoomList")
-  public List<RoomGetDto> initSpareCacheStorage() {
-    List<Room> spareMentoringRoomList = roomRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(1, 100));
-    return spareMentoringRoomList.stream().map(room -> entityToDto(room)).toList();
-  }
-
-  // 기본적으로 예비 저장소에는 한 묶음의 데이터가 모두 조회되고 뒤의 데이터를 더 요청할 것을 대비한 데이터가 들어있다.
-  // 첫 목록 조회 요청(페이지 방문), 새로 고침 등의 상황에서 가져온 첫 데이터를 기준으로 예비 데이터는,
-  // 앞에서 조회된 데이터의 마지막 createdAt을 기준으로 보다 늦게 생성된 데이터 중 한 묶음(size = 100)을 가지고 있게 된다.
-  @Override
-  @Cacheable(value = "spareMentoringRoomList")
-  public List<RoomGetDto> getAndUpdateSpareCacheStorage(LocalDateTime lastDateTime) {
-    // 앞 데이터를 모두 조회했을 때 불러올 일종의 예비 데이터
-    List<Room> spareMentoringRoomList = roomRepository.findAllByCreatedAtBeforeOrderByCreatedAtDesc(lastDateTime, PageRequest.of(0, 100));
-    return spareMentoringRoomList.stream().map(room -> entityToDto(room)).toList();
   }
 }

--- a/src/main/java/com/developers/live/mentoring/service/RegisterServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/RegisterServiceImpl.java
@@ -38,20 +38,20 @@ public class RegisterServiceImpl implements RegisterService {
           schedule.get().changeMentee(request.getMenteeId());
 
           return RegisterResponseDto.builder()
-                  .code(String.valueOf(HttpStatus.OK))
+                  .code(HttpStatus.OK.toString())
                   .msg("정상적으로 신청이 완료되었습니다.")
                   .data(String.valueOf(request.getMenteeId()))
                   .build();
         }
       }
       return RegisterResponseDto.builder()
-              .code(String.valueOf(HttpStatus.NOT_FOUND))
+              .code(HttpStatus.NOT_FOUND.toString())
               .msg("이미 예약된 멘토링 일정입니다.")
               .data(null)
               .build();
     }
     return RegisterResponseDto.builder()
-            .code(HttpStatus.NOT_FOUND.name())
+            .code(HttpStatus.NOT_FOUND.toString())
             .msg("해당 스케줄에 대한 정보를 찾지 못했습니다.")
             .data(null)
             .build();

--- a/src/main/java/com/developers/live/mentoring/service/RegisterServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/RegisterServiceImpl.java
@@ -7,7 +7,7 @@ import com.developers.live.mentoring.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +34,6 @@ public class RegisterServiceImpl implements RegisterService {
         Long registeredMentee = Long.parseLong(String.valueOf(valueOperations.get(String.valueOf(request.getScheduleId()))));
 
         if (request.getMenteeId().equals(registeredMentee)) {
-          // TODO: 사용자 측에 포인트 차감 요청
           schedule.get().changeMentee(request.getMenteeId());
 
           return RegisterResponseDto.builder()

--- a/src/main/java/com/developers/live/mentoring/service/RoomService.java
+++ b/src/main/java/com/developers/live/mentoring/service/RoomService.java
@@ -15,10 +15,9 @@ import java.util.Map;
 
 public interface RoomService {
 
-  // 첫번째, 예비 저장소 모두 업데이트 하는 메서드
-  void initCacheStorage();
+  void syncWithData();
   RoomListResponseDto getFirstCacheList();
-  RoomListResponseDto getSpareCacheList(LocalDateTime lastDateTime);
+  RoomListResponseDto getNextList(LocalDateTime lastDateTime);
   RoomAddResponseDto addRoom(RoomAddRequestDto req);
   RoomUpdateResponseDto updateRoom(RoomUpdateRequestDto req);
   RoomDeleteResponseDto deleteRoom(Long mentoringRoomId);

--- a/src/main/java/com/developers/live/mentoring/service/RoomServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/RoomServiceImpl.java
@@ -40,7 +40,7 @@ public class RoomServiceImpl implements RoomService {
   @Override
   public RoomListResponseDto getFirstCacheList() {
     return RoomListResponseDto.builder()
-            .code(HttpStatus.OK.name())
+            .code(HttpStatus.OK.toString())
             .msg("첫번째 캐시 저장소에 저장된 데이터")
             .data(cachingRoomService.getAndUpdateFirstCacheStorage())
             .build();
@@ -49,7 +49,7 @@ public class RoomServiceImpl implements RoomService {
   @Override
   public RoomListResponseDto getSpareCacheList(LocalDateTime lastDateTime) {
     RoomListResponseDto response = RoomListResponseDto.builder()
-            .code(HttpStatus.OK.name())
+            .code(HttpStatus.OK.toString())
             .msg("예비 캐시 저장소에 저장된 데이터")
             .data(cachingRoomService.getAndUpdateSpareCacheStorage(lastDateTime))
             .build();
@@ -72,7 +72,7 @@ public class RoomServiceImpl implements RoomService {
     );
 
     return RoomAddResponseDto.builder()
-            .code(String.valueOf(HttpStatus.OK))
+            .code(HttpStatus.OK.toString())
             .msg("정상적으로 채팅방을 생성하였습니다.")
             .data(String.valueOf(result.getMentoringRoomId()))
             .build();
@@ -90,14 +90,14 @@ public class RoomServiceImpl implements RoomService {
       room.updateRoomInfo(req.getTitle().replaceAll("\\s+", " "), req.getDescription());
 
       response = RoomUpdateResponseDto.builder()
-              .code(HttpStatus.OK.name())
+              .code(HttpStatus.OK.toString())
               .msg("방 정보 수정이 완료되었습니다.")
               .data(String.valueOf(req.getMentoringRoomId()))
               .build();
     }
     else {
       response = RoomUpdateResponseDto.builder()
-              .code(HttpStatus.NOT_FOUND.name())
+              .code(HttpStatus.NOT_FOUND.toString())
               .msg("수정하려는 방의 정보를 찾을 수 없습니다.")
               .data(null)
               .build();
@@ -113,7 +113,7 @@ public class RoomServiceImpl implements RoomService {
     for (Schedule schedule : scheduleList) {
       if (schedule.getMenteeId() != null) {
         return RoomDeleteResponseDto.builder()
-                .code(HttpStatus.BAD_REQUEST.name())
+                .code(HttpStatus.BAD_REQUEST.toString())
                 .msg("아직 멘티가 잡혀있는 일정이 있기에 삭제가 불가능합니다.")
                 .data(null)
                 .build();
@@ -123,7 +123,7 @@ public class RoomServiceImpl implements RoomService {
     roomRepository.deleteById(mentoringRoomId);
 
     return RoomDeleteResponseDto.builder()
-            .code(HttpStatus.OK.name())
+            .code(HttpStatus.OK.toString())
             .msg("정상적으로 멘토링룸 삭제가 완료되었습니다.")
             .data(String.valueOf(mentoringRoomId))
             .build();
@@ -136,7 +136,7 @@ public class RoomServiceImpl implements RoomService {
     List<RoomGetDto> dtoList = roomList.stream().map(room -> entityToDto(room)).toList();
 
     return RoomListResponseDto.builder()
-            .code(HttpStatus.OK.name())
+            .code(HttpStatus.OK.toString())
             .msg("검색어로 멘토링룸 목록 조회가 완료되었습니다.")
             .data(dtoList)
             .build();

--- a/src/main/java/com/developers/live/mentoring/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/ScheduleServiceImpl.java
@@ -37,14 +37,14 @@ public class ScheduleServiceImpl implements ScheduleService {
                       .build());
 
       response = ScheduleAddResponseDto.builder()
-              .code(String.valueOf(HttpStatus.OK))
+              .code(HttpStatus.OK.toString())
               .msg("일정이 추가되었습니다.")
               .data(String.valueOf(schedule.getScheduleId()))
               .build();
     }
     else {
       response = ScheduleAddResponseDto.builder()
-              .code(String.valueOf(HttpStatus.NOT_FOUND))
+              .code(HttpStatus.NOT_FOUND.toString())
               .msg("해당 스케줄에 대한 정보를 찾지 못했습니다.")
               .data(null)
               .build();
@@ -65,14 +65,14 @@ public class ScheduleServiceImpl implements ScheduleService {
         scheduleRepository.deleteById(scheduleId);
 
         return ScheduleDeleteResponseDto.builder()
-                .code(HttpStatus.OK.name())
+                .code(HttpStatus.OK.toString())
                 .msg("정상적으로 멘토링 일정이 취소되었습니다.")
                 .data(String.valueOf(scheduleId))
                 .build();
       }
       else {
         return ScheduleDeleteResponseDto.builder()
-                .code(HttpStatus.BAD_REQUEST.name())
+                .code(HttpStatus.BAD_REQUEST.toString())
                 .msg("이미 일정에 신청한 사용자가 있어 일정 취소가 불가능합니다.")
                 .data(null)
                 .build();
@@ -80,7 +80,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
     else {
       return ScheduleDeleteResponseDto.builder()
-              .code(HttpStatus.NOT_FOUND.name())
+              .code(HttpStatus.NOT_FOUND.toString())
               .msg("스케쥴에 대한 정보를 찾을 수 없습니다.")
               .data(null)
               .build();
@@ -98,14 +98,14 @@ public class ScheduleServiceImpl implements ScheduleService {
       optionalSchedule.get().changeMentee(null);
 
       return ScheduleDeleteResponseDto.builder()
-              .code(HttpStatus.OK.name())
+              .code(HttpStatus.OK.toString())
               .msg("정상적으로 신청이 취소되었습니다.")
               .data(String.valueOf(scheduleId))
               .build();
     }
     else {
       return ScheduleDeleteResponseDto.builder()
-              .code(HttpStatus.NOT_FOUND.name())
+              .code(HttpStatus.NOT_FOUND.toString())
               .msg("해당 스케쥴에 대한 정보가 없습니다.")
               .data(null)
               .build();
@@ -117,7 +117,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     List<ScheduleGetDto> dtoList = scheduleRepository.findAllByMentorId(memberId).stream().map(schedule -> entityToDto(schedule)).toList();
 
     return ScheduleListResponseDto.builder()
-            .code(String.valueOf(HttpStatus.OK))
+            .code(HttpStatus.OK.toString())
             .msg("멘토로서의 일정 조회가 완료되었습니다.")
             .data(dtoList)
             .build();
@@ -128,7 +128,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     List<ScheduleGetDto> dtoList = scheduleRepository.findAllByMenteeId(memberId).stream().map(schedule -> entityToDto(schedule)).toList();
 
     return ScheduleListResponseDto.builder()
-            .code(String.valueOf(HttpStatus.OK))
+            .code(HttpStatus.OK.toString())
             .msg("멘티로서의 일정 조회가 완료되었습니다.")
             .data(dtoList)
             .build();

--- a/src/test/java/com/developers/live/service/RegisterServiceTest.java
+++ b/src/test/java/com/developers/live/service/RegisterServiceTest.java
@@ -10,11 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -35,7 +32,7 @@ public class RegisterServiceTest {
     RegisterResponseDto response = registerService.register(request);
 
     // then
-    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
     assertThat(response.getData()).isEqualTo(String.valueOf(request.getMenteeId()));
   }
 

--- a/src/test/java/com/developers/live/service/RoomServiceTest.java
+++ b/src/test/java/com/developers/live/service/RoomServiceTest.java
@@ -1,12 +1,15 @@
 package com.developers.live.service;
 
-import com.developers.live.mentoring.dto.RoomAddRequestDto;
-import com.developers.live.mentoring.dto.RoomAddResponseDto;
+import com.developers.live.mentoring.dto.*;
 import com.developers.live.mentoring.service.RoomService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -29,6 +32,61 @@ public class RoomServiceTest {
     RoomAddResponseDto response = roomService.addRoom(req);
 
     // then
-    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  @Test
+  void 멘토링룸_정보_수정() {
+    // given
+    RoomUpdateRequestDto req = RoomUpdateRequestDto.builder()
+            .mentoringRoomId(1L)
+            .title("방제 수정이요!")
+            .description("내용 수정이요!")
+            .build();
+
+    // when
+    RoomUpdateResponseDto response = roomService.updateRoom(req);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  @Test
+  void 멘토링룸_삭제() {
+    // given
+    Long mentoringRoomId = 1L;
+
+    // when
+    RoomDeleteResponseDto response = roomService.deleteRoom(mentoringRoomId);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  @Test
+  void 멘토링룸_조회() {
+    // given
+
+    // when
+    RoomListResponseDto response = roomService.getFirstCacheList();
+
+    // then
+    System.out.println(response.getData());
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  @Test
+  void 날짜데이터로_멘토링룸_조회() {
+    // given
+    List<RoomGetDto> roomList = roomService.getFirstCacheList().getData();
+    LocalDateTime lastDateTime = roomList.get(10).getCreatedAt();
+
+    // when
+    RoomListResponseDto response = roomService.getNextList(lastDateTime);
+
+    // then
+    System.out.println(response);
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+    assertThat(response.getData().get(0).getCreatedAt()).isBefore(lastDateTime);
   }
 }

--- a/src/test/java/com/developers/live/service/ScheduleServiceTest.java
+++ b/src/test/java/com/developers/live/service/ScheduleServiceTest.java
@@ -2,6 +2,7 @@ package com.developers.live.service;
 
 import com.developers.live.mentoring.dto.ScheduleAddRequestDto;
 import com.developers.live.mentoring.dto.ScheduleAddResponseDto;
+import com.developers.live.mentoring.dto.ScheduleDeleteResponseDto;
 import com.developers.live.mentoring.dto.ScheduleListResponseDto;
 import com.developers.live.mentoring.entity.Schedule;
 import com.developers.live.mentoring.service.ScheduleService;
@@ -11,9 +12,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
-import java.util.stream.LongStream;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.in;
 
 @SpringBootTest
 public class ScheduleServiceTest {
@@ -34,7 +36,35 @@ public class ScheduleServiceTest {
     ScheduleAddResponseDto response = scheduleService.addSchedule(req);
 
     // then
-    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  @Test
+  public void 멘토_스케쥴_삭제() {
+    // given
+    ScheduleListResponseDto scheduleList = scheduleService.getScheduleListAsMentor(1L);
+    int lastDataIndex = scheduleList.getData().size() - 1;
+    long scheduleId = scheduleList.getData().get(lastDataIndex).getScheduleId();
+
+    // when
+    ScheduleDeleteResponseDto response = scheduleService.deleteScheduleAsMentor(scheduleId);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
+
+  @Test
+  public void 멘티의_멘토링_취소() {
+    // given
+    ScheduleListResponseDto scheduleList = scheduleService.getScheduleListAsMentee(3L);
+    int lastDataIndex = scheduleList.getData().size() - 1;
+    long scheduleId = scheduleList.getData().get(lastDataIndex).getScheduleId();
+
+    // when
+    ScheduleDeleteResponseDto response = scheduleService.deleteScheduleAsMentee(scheduleId);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
   }
 
   @Test
@@ -46,8 +76,18 @@ public class ScheduleServiceTest {
     ScheduleListResponseDto response = scheduleService.getScheduleListAsMentor(memberId);
 
     // then
-    assertThat(response.getCode()).isEqualTo(String.valueOf(HttpStatus.OK));
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
   }
 
-  // 멘티 스케쥴 조회
+  @Test
+  public void 멘티_스케쥴_조회() {
+    // given
+    Long menteeId = 3L;
+
+    // when
+    ScheduleListResponseDto response = scheduleService.getScheduleListAsMentee(menteeId);
+
+    // then
+    assertThat(response.getCode()).isEqualTo(HttpStatus.OK.toString());
+  }
 }


### PR DESCRIPTION
## 🤔 Motivation
- 멘토링룸 목록 조회 API 수정
- 응답 데이터 형식 수정

<br>

## 💡 Key Changes
- 기존에 두개의 캐시 저장소를 사용해 하나는 항상 제일 앞 0~99번의 데이터를 가지고 있도록하고, 다른 하나는 예비 저장소로 두어 처음엔 100~199번의 데이터를 두고, cache hit가 일어날 때마다 200~299, ... 이어서 미리 가지고있도록 구현하려고 계획했었다. 하지만 생각보다 자주 데이터를 캐시에 업데이트하고 가져오는 일이 오히려 더 번거롭게 느껴졌고, 결과적으로 단순하게 하나의 캐시 저장소를 두고 0~99번의 데이터를 담아두고 2분마다 DB 에서 다시 추가된 데이터도 가져오도록 수정했다.
- 응답 데이터에서 `code`라는 이름으로 서버에서의 처리가 완료되었을 때 `HttpStatus.OK` 를 신호로 보냈었다. 기존에는 `name()` 메서드로 `OK` 라는 단어만 보내던 것을 `toString()` 메서드를 사용해 `200 OK` 를 전달하도록 수정했다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
