### PR TITLE
fix: 스케줄 조회 API 와 방 생성 갯수 제한

### DIFF
--- a/src/main/java/com/developers/live/mentoring/controller/RoomController.java
+++ b/src/main/java/com/developers/live/mentoring/controller/RoomController.java
@@ -63,4 +63,11 @@ public class RoomController {
         log.info("검색어 이용해 방 목록 조회: " + response);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @GetMapping("/mentor/{mentorId}")
+    public ResponseEntity<RoomListResponseDto> roomListWithMentorId(@PathVariable Long mentorId) {
+        RoomListResponseDto response = roomService.getRoomWithMentorId(mentorId);
+        log.info("멘토 Id로 방 목록 조회: " + response);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/com/developers/live/mentoring/controller/ScheduleController.java
+++ b/src/main/java/com/developers/live/mentoring/controller/ScheduleController.java
@@ -1,7 +1,7 @@
 package com.developers.live.mentoring.controller;
 
-import com.developers.live.mentoring.service.ScheduleService;
 import com.developers.live.mentoring.dto.*;
+import com.developers.live.mentoring.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -56,6 +56,13 @@ public class ScheduleController {
   public ResponseEntity<MentoringEndResponseDto> endMentoring(@PathVariable Long scheduleId) {
     MentoringEndResponseDto response = scheduleService.endMentoring(scheduleId);
     log.info("회의 종료 후 관련 데이터 정리 요청 API: " + response);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @GetMapping("/{mentoringRoomId}")
+  public ResponseEntity<ScheduleListResponseDto> getMentoringRoomSchedules(@PathVariable Long mentoringRoomId) {
+    ScheduleListResponseDto response = scheduleService.getMentoringRoomSchedules(mentoringRoomId);
+    log.info("신청 가능한 스케쥴 조회 API: " + response);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/com/developers/live/mentoring/dto/ScheduleGetDto.java
+++ b/src/main/java/com/developers/live/mentoring/dto/ScheduleGetDto.java
@@ -16,6 +16,6 @@ public class ScheduleGetDto {
   private String mentoringRoomTitle;
   private String mentorName;
   private String menteeName;
-  private LocalDateTime start;
-  private LocalDateTime end;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
 }

--- a/src/main/java/com/developers/live/mentoring/repository/RoomRepository.java
+++ b/src/main/java/com/developers/live/mentoring/repository/RoomRepository.java
@@ -12,4 +12,5 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
   List<Room> findByTitleContaining(String param);
   List<Room> findAllByOrderByCreatedAtDesc(Pageable pageable);
   List<Room> findAllByCreatedAtBeforeOrderByCreatedAtDesc(LocalDateTime lastDateTime, Pageable pageable);
+  List<Room> findAllByMentorId(Long mentorId);
 }

--- a/src/main/java/com/developers/live/mentoring/repository/ScheduleRepository.java
+++ b/src/main/java/com/developers/live/mentoring/repository/ScheduleRepository.java
@@ -2,6 +2,7 @@ package com.developers.live.mentoring.repository;
 
 import com.developers.live.mentoring.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +13,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
   List<Schedule> findAllByMentorId(Long memberId);
   List<Schedule> findAllByMenteeId(Long memberId);
   List<Schedule> findAllByMentoringRoomId(Long mentoringRoomId);
+  List<Schedule> findAllByMentoringRoomIdAndMenteeIdIsNull(Long mentoringRoomId);
 }

--- a/src/main/java/com/developers/live/mentoring/service/RoomService.java
+++ b/src/main/java/com/developers/live/mentoring/service/RoomService.java
@@ -22,6 +22,7 @@ public interface RoomService {
   RoomUpdateResponseDto updateRoom(RoomUpdateRequestDto req);
   RoomDeleteResponseDto deleteRoom(Long mentoringRoomId);
   RoomListResponseDto getRoomWithSearchingWord(String searchingWord);
+  RoomListResponseDto getRoomWithMentorId(Long mentorId);
 
   default String getMentorName(Long mentorId) {
     RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/com/developers/live/mentoring/service/RoomServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/RoomServiceImpl.java
@@ -57,6 +57,13 @@ public class RoomServiceImpl implements RoomService {
 
   @Override
   public RoomAddResponseDto addRoom(RoomAddRequestDto req) {
+    if (roomRepository.findAllByMentorId(req.getMentorId()).size() >= 20) {
+      return RoomAddResponseDto.builder()
+              .code(HttpStatus.BAD_REQUEST.toString())
+              .msg("방은 최대 20개까지만 생성할 수 있습니다.")
+              .data(null)
+              .build();
+    }
     Room result = roomRepository.save(
             Room.builder()
             .mentorId(req.getMentorId())
@@ -134,6 +141,18 @@ public class RoomServiceImpl implements RoomService {
     return RoomListResponseDto.builder()
             .code(HttpStatus.OK.toString())
             .msg("검색어로 멘토링룸 목록 조회가 완료되었습니다.")
+            .data(dtoList)
+            .build();
+  }
+
+  @Override
+  public RoomListResponseDto getRoomWithMentorId(Long mentorId) {
+    List<Room> roomList = roomRepository.findAllByMentorId(mentorId);
+    List<RoomGetDto> dtoList = roomList.stream().map(room -> entityToDto(room)).toList();
+
+    return RoomListResponseDto.builder()
+            .code(HttpStatus.OK.toString())
+            .msg("멘토 Id로 멘토링룸 조회가 완료되었습니다.")
             .data(dtoList)
             .build();
   }

--- a/src/main/java/com/developers/live/mentoring/service/ScheduleService.java
+++ b/src/main/java/com/developers/live/mentoring/service/ScheduleService.java
@@ -21,6 +21,7 @@ public interface ScheduleService {
   ScheduleListResponseDto getScheduleListAsMentee(Long memberId);
   String getMentoringRoomTitle(Long mentoringRoomId);
   MentoringEndResponseDto endMentoring(Long scheduleId);
+  ScheduleListResponseDto getMentoringRoomSchedules(Long mentoringRoomId);
 
   RestTemplate restTemplate = new RestTemplate();
 
@@ -67,8 +68,8 @@ public interface ScheduleService {
             .mentoringRoomTitle(getMentoringRoomTitle(entity.getMentoringRoomId()))
             .mentorName(getMentorName(entity.getMentorId()))
             .menteeName(entity.getMenteeId() == null ? null : getMemberName(entity.getMenteeId()))
-            .start(entity.getStart())
-            .end(entity.getEnd())
+            .startDate(entity.getStart())
+            .endDate(entity.getEnd())
             .build();
   }
 }

--- a/src/main/java/com/developers/live/mentoring/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/ScheduleServiceImpl.java
@@ -170,4 +170,16 @@ public class ScheduleServiceImpl implements ScheduleService {
               .build();
     }
   }
+
+  @Override
+  public ScheduleListResponseDto getMentoringRoomSchedules(Long mentoringRoomId) {
+    List<Schedule> schedules = scheduleRepository.findAllByMentoringRoomIdAndMenteeIdIsNull(mentoringRoomId);
+    List<ScheduleGetDto> result = schedules.stream().map((schedule -> entityToDto(schedule))).toList();
+
+    return ScheduleListResponseDto.builder()
+            .code(HttpStatus.OK.toString())
+            .msg("신청가능한 스케쥴 목록입니다.")
+            .data(result)
+            .build();
+  }
 }


### PR DESCRIPTION
## 🤔 Motivation
- mentor Id로 해당 멘토가 만든 멘토링룸 조회 API 개발
- mentoringRoomId 로 해당 멘토링룸에 신청가능한 시간 조회 API 개발
- 방 생성 갯수 20개로 제한

<br>

## 💡 Key Changes
- mentor Id로 해당 멘토가 만든 멘토링룸 조회 API 개발
- mentoringRoomId 로 해당 멘토링룸에 신청가능한 시간 조회 API 개발
- 방 생성 갯수 20개로 제한

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team 
