### PR TITLE
fix: room list order by

### DIFF
--- a/src/main/java/com/developers/live/mentoring/repository/RoomRepository.java
+++ b/src/main/java/com/developers/live/mentoring/repository/RoomRepository.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
-  List<Room> findByTitleContaining(String param);
+  List<Room> findByTitleContainingOrderByCreatedAtDesc(String param);
   List<Room> findAllByOrderByCreatedAtDesc(Pageable pageable);
   List<Room> findAllByCreatedAtBeforeOrderByCreatedAtDesc(LocalDateTime lastDateTime, Pageable pageable);
-  List<Room> findAllByMentorId(Long mentorId);
+  List<Room> findAllByMentorIdOrderByCreatedAtDesc(Long mentorId);
   List<Room> findTop10ByOrderByCreatedAt();
 }

--- a/src/main/java/com/developers/live/mentoring/service/RoomServiceImpl.java
+++ b/src/main/java/com/developers/live/mentoring/service/RoomServiceImpl.java
@@ -57,7 +57,7 @@ public class RoomServiceImpl implements RoomService {
 
   @Override
   public RoomAddResponseDto addRoom(RoomAddRequestDto req) {
-    if (roomRepository.findAllByMentorId(req.getMentorId()).size() >= 20) {
+    if (roomRepository.findAllByMentorIdOrderByCreatedAtDesc(req.getMentorId()).size() >= 20) {
       return RoomAddResponseDto.builder()
               .code(HttpStatus.BAD_REQUEST.toString())
               .msg("방은 최대 20개까지만 생성할 수 있습니다.")
@@ -138,7 +138,7 @@ public class RoomServiceImpl implements RoomService {
   // 입력받은 검색어의 1개 이상 공백을 감지해 공백 1개로 치환한 후 방 검색 결과 리스트를 반환한다.
   @Override
   public RoomListResponseDto getRoomWithSearchingWord(String searchingWord) {
-    List<Room> roomList = roomRepository.findByTitleContaining(searchingWord.replaceAll("\\s+", " "));
+    List<Room> roomList = roomRepository.findByTitleContainingOrderByCreatedAtDesc(searchingWord.replaceAll("\\s+", " "));
     List<RoomGetDto> dtoList = roomList.stream().map(room -> entityToDto(room)).toList();
 
     return RoomListResponseDto.builder()
@@ -150,7 +150,7 @@ public class RoomServiceImpl implements RoomService {
 
   @Override
   public RoomListResponseDto getRoomWithMentorId(Long mentorId) {
-    List<Room> roomList = roomRepository.findAllByMentorId(mentorId);
+    List<Room> roomList = roomRepository.findAllByMentorIdOrderByCreatedAtDesc(mentorId);
     List<RoomGetDto> dtoList = roomList.stream().map(room -> entityToDto(room)).toList();
 
     return RoomListResponseDto.builder()


### PR DESCRIPTION
## 🤔 Motivation
- 멘토의 방 조회 및 검색 시 가져오는 방 목록 조회 결과 재정렬

<br>

## 💡 Key Changes
- 멘토의 방 조회 및 검색 시 가져오는 방 목록 조회 결과, 원래 `mentoringRoomId` 순으로 가져왔던 것을 `createdAt` 을 기준으로 내림차순(최신순)해서 가져오도록 수정했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @kcs-developers/start-dream-team @paduck-96 @Jooney-95 
